### PR TITLE
Typo in "A microscopic view of entropy"

### DIFF
--- a/statmech-primer.tex
+++ b/statmech-primer.tex
@@ -759,7 +759,7 @@ If we plot these, it looks something like this:
 \end{centering}
 
 As $T \rightarrow 0$, then the inverse temperature $\beta \rightarrow \infty$ and the lowest-energy state dominates the probability.
-On the other hand, as $T \rightarrow 0$, the exponential terms all become unity, and the probabilities of each state approach the proportion of their volumes in configuration space.
+On the other hand, as $T \rightarrow \infty$, the exponential terms all become unity, and the probabilities of each state approach the proportion of their volumes in configuration space.
 
 Now, let's compute the free energies of the two states:
 \begin{eqnarray}


### PR DESCRIPTION
The paragraph discussing what happens to probabilities as temperature varies repeats T -> 0, when the latter sentence should be T -> infinity. I have corrected it.

I haven't recompiled the pdf.

Hope this is useful!